### PR TITLE
Fix paths in `conda-ci` and remove `scripts` submodule

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -32,8 +32,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #2
@@ -45,8 +43,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #3
@@ -57,8 +53,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #4
@@ -69,8 +63,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #5
@@ -81,8 +73,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #6
@@ -94,8 +84,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #7
@@ -107,8 +95,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #8
@@ -120,8 +106,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #9
@@ -133,8 +117,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #10
@@ -146,8 +128,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #11
@@ -159,8 +139,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #12
@@ -171,8 +149,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #13
@@ -184,8 +160,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #14
@@ -196,8 +170,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #15
@@ -208,8 +180,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #16
@@ -220,8 +190,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #17
@@ -233,8 +201,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #18
@@ -246,8 +212,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - run: brew install coreutils autoconf automake libtool
       - uses: hdl/conda-ci@master
 
@@ -260,8 +224,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #20
@@ -273,8 +235,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #21
@@ -285,8 +245,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #22
@@ -298,8 +256,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #23
@@ -311,8 +267,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #24
@@ -324,22 +278,27 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
+
 
   master-package:
     runs-on: "ubuntu-20.04"
     env:
       OS_NAME: "linux"
+      CI_SCRIPTS_REL_PATH: "conda-ci"
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          repository: hdl/conda-ci
+          ref: master
+          path: ${{ env.CI_SCRIPTS_REL_PATH }}
       - uses: actions/setup-python@v1
       - uses: BSFishy/pip-action@v1
         with:
           packages: urllib3
       - run: |
-          bash .github/scripts/install.sh
-          python .github/scripts/wait-for-statuses.py
+          # Required internally by the scripts to locate other scripts.
+          export CI_SCRIPTS_PATH="$GITHUB_WORKSPACE/$CI_SCRIPTS_REL_PATH"
+          bash $CI_SCRIPTS_PATH/install.sh
+          python $CI_SCRIPTS_PATH/wait-for-statuses.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "conda-ci"]
-	path = .github/scripts
-	url = https://github.com/hdl/conda-ci.git
-	branch = master

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ To build a package similarly to how the packages are built in the CI it is
 recommended to pass the following optional arguments:
 * `--channels litex-hub` – to search for build dependencies in the LiteX-Hub
   channel in addition to the recipe-specific channels (from its `condarc` file),
-* `--packages conda-build=3.20.3 python=3.7` – to use the same versions of
+* `--packages python=3.7` – to use the same versions of
   packages that influence building as in the CI.
 
 After preparing, the output `DIRECTORY` will contain subdirectories:
@@ -204,7 +204,7 @@ PREPARED_RECIPE_OUTPUTDIR=${PREPARED_RECIPE_OUTPUTDIR:-cbp-outdir}
 RECIPE_PATH=${RECIPE_PATH:-tools/flterm}
 
 # Prepare the RECIPE with `conda-build-prepare`
-ADDITIONAL_PACKAGES="conda-build=3.20.3 python=3.7"
+ADDITIONAL_PACKAGES="python=3.7"
 python3 -m conda_build_prepare               \
             --channels litex-hub             \
             --packages $ADDITIONAL_PACKAGES  \


### PR DESCRIPTION
The same changes as in hdl/conda-eda#152.

Let's see if the CI builds at least a few jobs properly to make sure there are no silly mistakes.